### PR TITLE
Update SIP reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Prerequisites
 
 * Ventura or newer
-* Disable [System Identity Protection](https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection).
+* Disable [System Integrity Protection](https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection).
 SIP [doesn't allow](https://github.com/containerd/containerd/discussions/5525#discussioncomment-2685649) to `chroot` (not needed for building though).
 
 ## Usage


### PR DESCRIPTION
This change corrects the reference to the System Integrity Protection technology in the `README.md` file and is consistent with the terminology used in other projects such as [darwin-containers/rund ](https://github.com/darwin-containers/rund).