### PR TITLE
Enable Monterey builds

### DIFF
--- a/darwinjail/main.py
+++ b/darwinjail/main.py
@@ -91,8 +91,9 @@ def copy_files(target_dir: str, queue: dict[str, CopyOpts]) -> None:
                     .split("\n")
                 )
             except subprocess.CalledProcessError as err:
-                if err.stdout.decode("UTF-8").startswith('LLVM ERROR: Sized aggregate specification in datalayout string'):
-                    print('Suppressing error: LLVM ERROR: Sized aggregate specification in datalayout string')
+                otool_error_datalayout = 'LLVM ERROR: Sized aggregate specification in datalayout string'
+                if err.stdout.decode("UTF-8").startswith(otool_error_datalayout):
+                    print(otool_error_datalayout)
                     print('for command:')
                     print(err.args)
 


### PR DESCRIPTION
- **Handle CalledProcessError for certain OpenCL .BC files**

LLVM tools for macOS Monterey (`LLVM version 14.0.0`) return an error status when running `otool` and encountering this condition:

```
Sized aggregate specification in datalayout string
```

(Note, later versions treat this as a warning).

This change catches the corresponding `supbrocess` exception when using that older toolset and continues with `copy_files` instead of failing the whole workflow.
